### PR TITLE
Problem with trailing whitespace

### DIFF
--- a/src/zcl_md4.clas.abap
+++ b/src/zcl_md4.clas.abap
@@ -126,7 +126,9 @@ CLASS ZCL_MD4 IMPLEMENTATION.
 
     lo_obj = cl_abap_conv_out_ce=>create( encoding = iv_encoding ).
 
-    lo_obj->convert( EXPORTING data = iv_string
+    lo_obj->convert( EXPORTING
+                       data = iv_string
+                       n = strlen( iv_string )
                      IMPORTING buffer = rv_xstring ).
 
   ENDMETHOD.


### PR DESCRIPTION
When the text to hash is in a fixed length field, the code page converter also converts any trailing spaces, leading to the first unit test failing (the empty string is internally a C(1) field containing one blank, making the resulting hash into the MD4 of a single space, not the empty string)